### PR TITLE
fixes vertical alignment of name and avatar icon

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -256,7 +256,7 @@ main {
 
   .name-and-avatar {
     display: inline-block;
-    height: $avatar-height;
+    height: 100%;
 
     .avatar {
       max-height: $avatar-height;


### PR DESCRIPTION
**In Safari 8.0.6.**
## Before:

![before](https://cloud.githubusercontent.com/assets/1493623/8208840/b645fc70-14d7-11e5-9ad5-05d53a97e02d.PNG)
## After:

![after](https://cloud.githubusercontent.com/assets/1493623/8208844/b897c1de-14d7-11e5-909a-35066af11cb5.PNG)
